### PR TITLE
polyaxon_cli config doc options fixes

### DIFF
--- a/docs/templates/installation/deploy_polyaxon.md
+++ b/docs/templates/installation/deploy_polyaxon.md
@@ -132,7 +132,7 @@ Polyaxon is currently running:
 
 2. Setup your cli by running theses commands:
 
-  polyaxon config set --host=$POLYAXON_IP --http-port=$POLYAXON_HTTP_PORT  --ws-port=$POLYAXON_WS_PORT
+  polyaxon config set --host=$POLYAXON_IP --http_port=$POLYAXON_HTTP_PORT  --ws_port=$POLYAXON_WS_PORT
 
 
 3. Log in with superuser

--- a/docs/templates/polyaxon_cli/commands/config.md
+++ b/docs/templates/polyaxon_cli/commands/config.md
@@ -29,7 +29,7 @@ Set the global config values.
 Example:
 
 ```bash
-$ polyaxon config set --host=localhost http_port=80
+$ polyaxon config set --host=localhost --http_port=80
 ```
 
 Options:
@@ -38,7 +38,7 @@ option | type | description
 -------|------|------------
   --verbose| BOOLEAN | To set the verbosity of the client.
   --host| TEXT | To set the server endpoint.
-  --http-port| INTEGER | To set the http port.
-  --ws-port| INTEGER | To set the stream port.
+  --http_port| INTEGER | To set the http port.
+  --ws_port| INTEGER | To set the stream port.
   --use-https| BOOLEAN | To set the https.
   --help| | Show this message and exit..


### PR DESCRIPTION
This PR includes 2 commits, both responsible for an update to the official doc to reflect the current options http_port and ws_port for `polyaxon config set` during the initial configuration of the cli. 