### PR TITLE
Update instructions for deploying on minikube

### DIFF
--- a/docs/templates/installation/deploy_polyaxon.md
+++ b/docs/templates/installation/deploy_polyaxon.md
@@ -176,6 +176,15 @@ ingress:
 serviceType: LoadBalancer
 ```
 
+It is however recommended to enable RBAC and start minikube with the option `--extra-config=apiserver.authorization-mode=RBAC`.
+
+After installing polyaxon, use the following command to enable access to the API service:
+
+```bash
+minikube service -n polyaxon polyaxon-polyaxon-api
+```
+
+Note that when using minikube, the IP address of the application is given by `minikube ip`.
 
 ## Upgrade Polyaxon
 


### PR DESCRIPTION
I didn't not manage to get a working deployment of Polyaxon without running the `minikube service` command. Also I had to enable RBAC for the experiments to build properly.

Partially related to issue #308.