### PR TITLE
Remove `eventMonitors` from recommended services to scale

### DIFF
--- a/docs/configuration/replication-concurrency.md
+++ b/docs/configuration/replication-concurrency.md
@@ -43,9 +43,6 @@ hpsearch:
 
 eventsHandlers:
   replicas: 3
-
-eventMonitors:
-  replicas: 3
 ```
 
 ## Concurrency


### PR DESCRIPTION
As discussed, the eventMonitors should be set to 1. I will follow up with a PRs to update:
 * Charts to always default to one
 * Deployment validation to warn users about setting this value