### PR TITLE
Add GKE note to documentation

### DIFF
--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -28,7 +28,7 @@ Polyaxon's helm chart comes with an ingress resource that you can use with an in
     ```
     
 
- 2. Add the tls configuration to Polyaxon's Ingress values.
+ 2. Add the tls configuration to Polyaxon's Ingress values. **Do not use CluserIP on GKE**
  
     ```yaml
     serviceType: ClusterIP


### PR DESCRIPTION
This seemed to be the culprit for issues with experiment groups grinding to a halt if too many were being run at the same time. I found this note in a comment in the Helm values when looking for something to increase the log level.