### PR TITLE
Fix typo in declarations.md

### DIFF
--- a/docs/references/polyaxonfile-yaml-specification/declarations.md
+++ b/docs/references/polyaxonfile-yaml-specification/declarations.md
@@ -49,7 +49,7 @@ declarations:
 This declaration can be used to pass values to our program:
 
 ```yaml
- ... --batch-size={{ batch-size }}
+ ... --batch-size={{ batch_size }}
 ```
 Or
 ```yaml


### PR DESCRIPTION
Otherwise this would error with:
```
Polyaxonfile is not valid.
Error message `'batch' is undefined`.
```