### PR TITLE
Fix spelling tensorboard --> TensorBoard

### DIFF
--- a/client/src/components/projects/projectAdd.tsx
+++ b/client/src/components/projects/projectAdd.tsx
@@ -75,7 +75,7 @@ export default class ProjectAdd extends React.Component<Props, {}> {
               <i
                 className="fas fa-play fa-sm icon"
                 aria-hidden="true"
-              /> Start tensorboard
+              /> Start TensorBoard
             </MenuItem>
           </LinkContainer>
         </Dropdown.Menu>

--- a/docs/concepts/tensorboards.md
+++ b/docs/concepts/tensorboards.md
@@ -22,7 +22,7 @@ Polyaxon allows users to run tensorboard jobs on project, experiment, and experi
 [Tensorboard](https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard) is a visualization tool for Tensorflow projects.
 Tensorboard can help visualize the Tensorflow computation graph and plot quantitative metrics about your run.
 
-## Start tensorboard
+## Start TensorBoard
 
 We assume that you have already a [project](/concepts/projects/) created and initialized, and code uploaded.
 


### PR DESCRIPTION
The "official" spelling seams to be TensorBoard: https://www.tensorflow.org/tensorboard

This changes the UI elements to adhere to that.