### PR TITLE
Fix typo in RabbitMQ config docs.

### DIFF
--- a/docs/configuration/rabbitmq-ha.md
+++ b/docs/configuration/rabbitmq-ha.md
@@ -25,7 +25,7 @@ you need to disable the in-cluster Rabbitmq, and provide the information needed 
 
 
 ```yaml
-rabbitmq-hq:
+rabbitmq-ha:
   enabled: false
 
 externalServices:


### PR DESCRIPTION
This fixes #521.