### PR TITLE
Remove merge conflict markers in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 esudo: required
-<<<<<<< HEAD
 dist: xenial
 language: python
 


### PR DESCRIPTION
1307b86ee7a77e6aac1fcfc4cfe54263c9e3bd4b added some merge commit markers, that should be removed.