### PR TITLE
Fix some typo in api docs

### DIFF
--- a/docs/references/polyaxon-api/job.md
+++ b/docs/references/polyaxon-api/job.md
@@ -216,7 +216,7 @@ curl --request GET \
 
 <b>Example curl request</b>
 
-```json
+```
 curl --request POST \
   --url 'http://{{base_api_url}}/api/v1/{{username}}/{{project}}/jobs/{{id}}/restart' \
   --header 'Authorization: token {{token}}'

--- a/docs/references/polyaxon-api/project.md
+++ b/docs/references/polyaxon-api/project.md
@@ -309,7 +309,7 @@ curl -X POST \
 
 ## List experiments
 
-<span class="api api-post">
+<span class="api api-get">
 /api/v1/{username}/{project_name}/experiments/
 </span>>
 
@@ -610,7 +610,7 @@ curl -X GET \
 
 ## Start project tensorboard
 
-<span class="api api-pot">
+<span class="api api-post">
 /api/v1/{username}/{project_name}/tensorboard/start/
 </span>
 


### PR DESCRIPTION
Fixed typo pot -> post, api-post -> api-get and delete extra `json`.