### PR TITLE
Update Helm installation instructions for helm 3

### DIFF
--- a/docs/setup/kubernetes.md
+++ b/docs/setup/kubernetes.md
@@ -106,8 +106,7 @@ polyaxon admin deploy -f config.yml
 Or you can use Helm to do the same:
 
 ```bash
-helm install polyaxon/polyaxon \
-    --name=<RELEASE_NAME> \
+helm install <RELEASE_NAME> polyaxon/polyaxon \
     --namespace=<NAMESPACE> \
     -f config.yml
 ```


### PR DESCRIPTION
With Helm 3 there is no `--name` flag, the release name is passed as an unnamed argument.