### PR TITLE
fix typo in polyaxonfile yaml specification

### DIFF
--- a/docs/references/polyaxonfile-yaml-specification.md
+++ b/docs/references/polyaxonfile-yaml-specification.md
@@ -63,7 +63,7 @@ The Polyaxon specification is based on a list of sections, in this guide, we des
 ## Tensorboard sections
 
  * [version](/references/polyaxonfile-yaml-specification/version/) `required`: defines the version of the file to be parsed and validated.
- * [kind](/references/polyaxonfile-yaml-specification/kind/) `required`: defines the kind of operation to run: plugin.
+ * [kind](/references/polyaxonfile-yaml-specification/kind/) `required`: defines the kind of operation to run: tensorboard.
  * [environment](/references/polyaxonfile-yaml-specification/environment/): defines the run environment, resources, persistence, and node selectors.
  * [build](/references/polyaxonfile-yaml-specification/build/) `required`: defines the how the user can set a docker image.
 

--- a/docs/references/polyaxonfile-yaml-specification/build.md
+++ b/docs/references/polyaxonfile-yaml-specification/build.md
@@ -39,19 +39,6 @@ build:
   env_vars:
     - [KEY1, VALUE1]
     - [KEY2, VALUE2]
-```
-
-## Example using commit
-
-```yaml
-build:
-  image: my_image
-  build_steps:
-    - pip install PILLOW
-    - pip install scikit-learn
-  env_vars:
-    - [KEY1, VALUE1]
-    - [KEY2, VALUE2]
   commit: 14e9d652151eb058afa0b51ba110671f2ca10cbf
 ```
 

--- a/docs/references/polyaxonfile-yaml-specification/environment.md
+++ b/docs/references/polyaxonfile-yaml-specification/environment.md
@@ -355,14 +355,15 @@ environment:
             - key: "key"
               operator: "Exists"
 
-      ps_resources:
+      ps:
         - index: 0
-          cpu:
-            requests: 1
-            limits: 1
-          memory:
-            requests: 256
-            limits: 1024
+          resources:
+            cpu:
+              requests: 1
+              limits: 1
+            memory:
+              requests: 256
+              limits: 1024
 ```
 
 ## framework: mxnet


### PR DESCRIPTION
fix some typos in polyaxonfile yaml specification: 
1. Overview -> Tensorboard section, run: plugin -> run: tensorboard.
2. Build, Examples has replicated "Example using commit"
3. Environment, ps_resources -> ps