### PR TITLE
[RBAC] extensions apiGroup is needed for tensorboard and notebook

### DIFF
--- a/helm/platform/templates/sa.yaml
+++ b/helm/platform/templates/sa.yaml
@@ -95,7 +95,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
     verbs: ["get", "update", "patch", "create", "delete"]
-  - apiGroups: ["", "apps"]
+  - apiGroups: ["", "apps", "extensions"]
     resources: ["services", "deployments", "replicasets"]
     verbs: ["get", "create", "patch", "delete", "list"]
   - apiGroups: ["", "extensions"]


### PR DESCRIPTION
If RBAC is active, tensorboard and notebook are not starting due to:
```
"system:serviceaccount:polyaxon:polyaxon-polyaxon-serviceaccount\" cannot patch resource \"deployments\"
```

This is due extensions missing in serviceaccount chart.