### PR TITLE
Slack invite links outdated

### DIFF
--- a/dockerizer/README.md
+++ b/dockerizer/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/polyaxon-dockerizer.svg)](https://badge.fury.io/py/polyaxon-dockerizer)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a33947d729f94f5da7f7390dfeef7f94)](https://www.codacy.com/app/polyaxon/polyaxon-dockerizer?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=polyaxon/polyaxon-dockerizer&amp;utm_campaign=Badge_Grade)
-[![Slack](https://img.shields.io/badge/chat-on%20slack-aadada.svg?logo=slack&longCache=true)](https://join.slack.com/t/polyaxon/shared_invite/enQtMzQ0ODc2MDg1ODc0LWY2ZTdkMTNmZjBlZmRmNjQxYmYwMTBiMDZiMWJhODI2ZTk0MDU4Mjg5YzA5M2NhYzc5ZjhiMjczMDllYmQ2MDg)
+[![Slack](https://img.shields.io/badge/chat-on%20slack-aadada.svg?logo=slack&longCache=true)](https://join.slack.com/t/polyaxon/shared_invite/henQtMzQ0ODc2MDg1ODc0LTViMjMwY2VlNjQzYzU2NTUzODVlNzBjNDc2NDMyY2M0MDljMDliOWViNDljMDNmZmViZTg1YzFlOWY0YTQwMTM)
 
 
 # polyaxon-dockerizer
@@ -20,7 +20,7 @@ $ pip install -U polyaxon-dockerizer
 
 ```python
 from polyaxon_dockerizer import generate
-         
+
 generate(repo_path,
          from_image,
          build_steps=['apt-get install git', 'pip install tensorflow'],

--- a/docs/concepts/contributing.md
+++ b/docs/concepts/contributing.md
@@ -15,8 +15,8 @@ Polyaxon is an open source software, and we would be happy to welcome your contr
 
 ## Development guide
 
-If you're a developer looking to help, but you're not sure where to begin: 
-Check out the [good first issue](https://github.com/polyaxon/polyaxon/labels/good%20first%20issue) label on Github, 
+If you're a developer looking to help, but you're not sure where to begin:
+Check out the [good first issue](https://github.com/polyaxon/polyaxon/labels/good%20first%20issue) label on Github,
 which contains small piece of work that have been specifically flagged as being friendly to new contributors.
 
 Or, if you're looking for something a little more challenging, there's a broader [help wanted](https://github.com/polyaxon/polyaxon/labels/help%20wanted) label.
@@ -28,7 +28,7 @@ When you're ready, check out the full **[Polyaxon Contributing Guide](https://gi
 
 The primary way to contribute to Polyaxon is by writing code, but if you're not a developer there are still ways you can help. We always need help with:
 
-- Helping other Polyaxon users on [the community channel](https://join.slack.com/t/polyaxon/shared_invite/enQtMzQ0ODc2MDg1ODc0LWY2ZTdkMTNmZjBlZmRmNjQxYmYwMTBiMDZiMWJhODI2ZTk0MDU4Mjg5YzA5M2NhYzc5ZjhiMjczMDllYmQ2MDg).
+- Helping other Polyaxon users on [the community channel](https://join.slack.com/t/polyaxon/shared_invite/henQtMzQ0ODc2MDg1ODc0LTViMjMwY2VlNjQzYzU2NTUzODVlNzBjNDc2NDMyY2M0MDljMDliOWViNDljMDNmZmViZTg1YzFlOWY0YTQwMTM).
 - Creating [guides and tutorials](/guides/) and authoring [plugins and integrations](/integrations/)
 - Improving our [documentation](https://github.com/polyaxon/polyaxon/tree/master/docs)
 - Testing and quality assurance

--- a/docs/concepts/introduction.md
+++ b/docs/concepts/introduction.md
@@ -10,7 +10,7 @@ tags:
     - training
     - scale
     - scheduling
-    - platform 
+    - platform
     - kubernetes
     - helm
     - containers
@@ -27,8 +27,8 @@ Polyaxon deploys into any data center, cloud provider,
 or can be hosted and managed by Polyaxon,
 and it supports all the major deep learning frameworks such as Tensorflow, MXNet, Caffe, Torch, etc.
 
-Polyaxon makes it faster, easier, and more efficient to develop machine learning and deep learning applications. 
-It is designed for individuals, teams and organizations who need reproducibility, compliance, power, flexibility and performance. 
+Polyaxon makes it faster, easier, and more efficient to develop machine learning and deep learning applications.
+It is designed for individuals, teams and organizations who need reproducibility, compliance, power, flexibility and performance.
 It allows workloads scheduling with smart container and node management, and turns GPU servers into shared, self-service resources for your team or organization.
 
 Here  you will find a comprehensive guide for setting up Polyaxon on your cluster,
@@ -38,26 +38,26 @@ We do our best to make this documentation clear and user friendly,
 if you see anything that is incorrect or have any questions,
 feel free to reach out at the
 [issues page](https://github.com/polyaxon/polyaxon/issues),
-[forum](https://join.slack.com/t/polyaxon/shared_invite/enQtMzQ0ODc2MDg1ODc0LWY2ZTdkMTNmZjBlZmRmNjQxYmYwMTBiMDZiMWJhODI2ZTk0MDU4Mjg5YzA5M2NhYzc5ZjhiMjczMDllYmQ2MDg)
+[forum](https://join.slack.com/t/polyaxon/shared_invite/henQtMzQ0ODc2MDg1ODc0LTViMjMwY2VlNjQzYzU2NTUzODVlNzBjNDc2NDMyY2M0MDljMDliOWViNDljMDNmZmViZTg1YzFlOWY0YTQwMTM)
 or [contact us](mailto:contact@polyaxon.com).
 
 Please check our [quick start guide](/concepts/quick-start) to start training your first experiment.
 
-To gain a deeper understanding of how Polyaxon can help you iterate faster with your experiments, 
+To gain a deeper understanding of how Polyaxon can help you iterate faster with your experiments,
 please take some time to familiarize yourself with the [architecture & experimentation workflow](/concepts/architecture/)
 
 ## Mission
 
 Polyaxon’s mission is to make machine learning and deep learning simple and accessible to enterprises.
 
-Current advances in machine learning and deep learning have direct impact on business, 
-yet few companies are leveraging these latest technologies. 
-The data science space is still lacking good tooling and best practices 
-for organizing practitioners' workflows. It's particularly challenging 
+Current advances in machine learning and deep learning have direct impact on business,
+yet few companies are leveraging these latest technologies.
+The data science space is still lacking good tooling and best practices
+for organizing practitioners' workflows. It's particularly challenging
 because of the variety of tools and requirements used to develop production-ready models.
 
-Our goal is to enable Polyaxon's users to use rigorous practices and workflows to 
-go from reproducible and portable experiments to scalable model deployments.  
+Our goal is to enable Polyaxon's users to use rigorous practices and workflows to
+go from reproducible and portable experiments to scalable model deployments.
 
 ## How is Polyaxon different?
 
@@ -87,17 +87,17 @@ Before diving into Polyaxon's Features in the the next section, it's useful to g
 
 ### The blog
 
-For long-form news and announcements the best place to keep up to date with everything happening is [our blog](https://medium.com/polyaxon). 
-There's an [RSS feed](https://medium.com/feed/polyaxon) and 
+For long-form news and announcements the best place to keep up to date with everything happening is [our blog](https://medium.com/polyaxon).
+There's an [RSS feed](https://medium.com/feed/polyaxon) and
 also [a newsletter](https://polyaxon.us17.list-manage.com/subscribe/post?u=1b6eccb8409861418bcc5dbfc&id=012464842e).
 
 ### Community channel
 
-The [Polyaxon community channel](https://join.slack.com/t/polyaxon/shared_invite/enQtMzQ0ODc2MDg1ODc0LWY2ZTdkMTNmZjBlZmRmNjQxYmYwMTBiMDZiMWJhODI2ZTk0MDU4Mjg5YzA5M2NhYzc5ZjhiMjczMDllYmQ2MDg) is where to find other Polyaxon users.
+The [Polyaxon community channel](https://join.slack.com/t/polyaxon/shared_invite/henQtMzQ0ODc2MDg1ODc0LTViMjMwY2VlNjQzYzU2NTUzODVlNzBjNDc2NDMyY2M0MDljMDliOWViNDljMDNmZmViZTg1YzFlOWY0YTQwMTM) is where to find other Polyaxon users.
 
 ### Media links
 
-To keep in touch with people directly and give them updates about what's new with Polyaxon. 
+To keep in touch with people directly and give them updates about what's new with Polyaxon.
 Here are the easiest ways to keep track of Polyaxon:
 
 - [Github](https://github.com/polyaxon/polyaxon)
@@ -105,7 +105,7 @@ Here are the easiest ways to keep track of Polyaxon:
 
 ### Guides &  Tutorials
 
-We publish some [guides and tutorials](/guides/) from time to time to explain or clarify how to use our tools in a practical ways. 
+We publish some [guides and tutorials](/guides/) from time to time to explain or clarify how to use our tools in a practical ways.
 These guides have tags, you can for instance show all guides for a particular tag to gain deeper knowledge about that area.
 
 ### Frequently asked questions
@@ -113,5 +113,5 @@ These guides have tags, you can for instance show all guides for a particular ta
 **Don't forget!** If you have any questions or problems the best places to start is the search box on this page, which will immediately return all results from across our documentation and [FAQ](/faq/) archive.
 
 
-If you have subscription to one of our enterprise editions (`PaaS` or `EE`), 
+If you have subscription to one of our enterprise editions (`PaaS` or `EE`),
 just drop us an email on `support@polyaxon.com` and we'll be more than happy to help.

--- a/helm/platform/README.md
+++ b/helm/platform/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/polyaxon/polyaxon-chart.svg?branch=master)](https://travis-ci.org/polyaxon/polyaxon-chart)
 [![Release](https://img.shields.io/badge/release-0.6.0-green.svg?longCache=true)](https://github.com/polyaxon/polyaxon/releases/tag/0.6.0)
-[![Slack](https://img.shields.io/badge/chat-on%20slack-aadada.svg?logo=slack&longCache=true)](https://join.slack.com/t/polyaxon/shared_invite/enQtMzQ0ODc2MDg1ODc0LWY2ZTdkMTNmZjBlZmRmNjQxYmYwMTBiMDZiMWJhODI2ZTk0MDU4Mjg5YzA5M2NhYzc5ZjhiMjczMDllYmQ2MDg)
+[![Slack](https://img.shields.io/badge/chat-on%20slack-aadada.svg?logo=slack&longCache=true)](https://join.slack.com/t/polyaxon/shared_invite/henQtMzQ0ODc2MDg1ODc0LTViMjMwY2VlNjQzYzU2NTUzODVlNzBjNDc2NDMyY2M0MDljMDliOWViNDljMDNmZmViZTg1YzFlOWY0YTQwMTM)
 
 Polyaxon chart is a Helm chart for creating reproducible and maintainable deployments of Polyaxon with Kubernetes.
 

--- a/platform/core/polyaxon/api/templates/polyaxon/footer.html
+++ b/platform/core/polyaxon/api/templates/polyaxon/footer.html
@@ -75,7 +75,7 @@
                         <a href="https://github.com/polyaxon/polyaxon/issues">Issue Tracker</a>
                     </li>
                     <li>
-                        <a href="https://join.slack.com/t/polyaxon/shared_invite/enQtMzQ0ODc2MDg1ODc0LWY2ZTdkMTNmZjBlZmRmNjQxYmYwMTBiMDZiMWJhODI2ZTk0MDU4Mjg5YzA5M2NhYzc5ZjhiMjczMDllYmQ2MDg">Slack Channel</a>
+                        <a href="https://join.slack.com/t/polyaxon/shared_invite/henQtMzQ0ODc2MDg1ODc0LTViMjMwY2VlNjQzYzU2NTUzODVlNzBjNDc2NDMyY2M0MDljMDliOWViNDljMDNmZmViZTg1YzFlOWY0YTQwMTM">Slack Channel</a>
                     </li>
                     <li>
                         <a href="mailto:contact@polyaxon.com">Contact Us</a>


### PR DESCRIPTION
Old Slack invite link isn't working anymore. Substituted with the one from official polyaxon website.