### PR TITLE
Fix polyaxon admin commands when calling without a config file

### DIFF
--- a/core/polyaxon/cli/admin.py
+++ b/core/polyaxon/cli/admin.py
@@ -81,9 +81,10 @@ def deploy(config_file, manager_path, check, dry_run):
         config=config, filepath=config_file, manager_path=manager_path, dry_run=dry_run
     )
     exception = None
-    Printer.print_success(
-        "Polyaxon `{}` deployment file is valid.".format(config.deployment_chart)
-    )
+    if config:
+        Printer.print_success(
+            "Polyaxon `{}` deployment file is valid.".format(config.deployment_chart)
+        )
     if check:
         try:
             manager.check()
@@ -134,9 +135,10 @@ def upgrade(config_file, manager_path, check, dry_run):
         config=config, filepath=config_file, manager_path=manager_path, dry_run=dry_run
     )
     exception = None
-    Printer.print_success(
-        "Polyaxon `{}` deployment file is valid.".format(config.deployment_chart)
-    )
+    if config:
+        Printer.print_success(
+            "Polyaxon `{}` deployment file is valid.".format(config.deployment_chart)
+        )
     if check:
         try:
             manager.check()


### PR DESCRIPTION
Polyaxon v1 comes with sensible defaults for easy setup. However when calling `polyaxon admin deploy` or `polyaxon admin upgrade` without passing a config file it would fail with:
```python-traceback
$ polyaxon admin upgrade
Traceback (most recent call last):
  File "/usr/local/bin/polyaxon", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/polyaxon/logger.py", line 60, in clean_outputs_wrapper
    raise e
  File "/usr/local/lib/python3.7/site-packages/polyaxon/logger.py", line 54, in clean_outputs_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/polyaxon/cli/admin.py", line 147, in upgrade
    "Polyaxon `{}` deployment file is valid.".format(config.deployment_chart)
AttributeError: 'NoneType' object has no attribute 'deployment_chart'
```

This PR fixes the logging so a simple Polyaxon cluster to play around with can be deployed without passing a config file.