### PR TITLE
Add horovod single-node experiment polyaxon file examples for keras, tensorflow and pytorch

### DIFF
--- a/examples/in_cluster/horovod/keras/single-node-experiment.yml
+++ b/examples/in_cluster/horovod/keras/single-node-experiment.yml
@@ -1,0 +1,24 @@
+---
+version: 1.1
+kind: component
+name: single-node-horovod-keras
+
+inputs:
+  - name: gpus
+    isOptional: true
+    type: int
+    value: 2
+
+run:
+  kind: job
+  init:
+    - git: {"url": "https://github.com/polyaxon/polyaxon-examples"}
+  container:
+      image: polyaxon/polyaxon-horvod-examples
+      workingDir: "{{ globals.artifacts_path }}/polyaxon-examples/in_cluster/horovod/keras"
+      resources:
+          limits:
+            nvidia.com/gpu: "{{ gpus }}"
+      command: ["horovodrun", "-np", "{{ gpus }}", "-H", "localhost:{{ gpus }}", "python", "-u", "mnist.py"]
+      imagePullPolicy: "Always"
+

--- a/examples/in_cluster/horovod/pytorch/single-node-experiment.yml
+++ b/examples/in_cluster/horovod/pytorch/single-node-experiment.yml
@@ -1,0 +1,24 @@
+---
+version: 1.1
+kind: component
+name: single-node-horovod-pytorch
+
+inputs:
+  - name: gpus
+    isOptional: true
+    type: int
+    value: 2
+
+run:
+  kind: job
+  init:
+    - git: {"url": "https://github.com/polyaxon/polyaxon-examples"}
+  container:
+      image: polyaxon/polyaxon-horvod-examples
+      workingDir: "{{ globals.artifacts_path }}/polyaxon-examples/in_cluster/horovod/pytorch"
+      resources:
+          limits:
+            nvidia.com/gpu: "{{ gpus }}"
+      command: ["horovodrun", "-np", "{{ gpus }}", "-H", "localhost:{{ gpus }}", "python", "-u", "mnist.py"]
+      imagePullPolicy: "Always"
+

--- a/examples/in_cluster/horovod/tensorflow/single-node-experiment.yml
+++ b/examples/in_cluster/horovod/tensorflow/single-node-experiment.yml
@@ -1,0 +1,24 @@
+---
+version: 1.1
+kind: component
+name: single-node-horovod-tensorflow
+
+inputs:
+  - name: gpus
+    isOptional: true
+    type: int
+    value: 2
+
+run:
+  kind: job
+  init:
+    - git: {"url": "https://github.com/polyaxon/polyaxon-examples"}
+  container:
+      image: polyaxon/polyaxon-horvod-examples
+      workingDir: "{{ globals.artifacts_path }}/polyaxon-examples/in_cluster/horovod/tensorflow"
+      resources:
+          limits:
+            nvidia.com/gpu: "{{ gpus }}"
+      command: ["horovodrun", "-np", "{{ gpus }}", "-H", "localhost:{{ gpus }}", "python", "-u", "mnist.py"]
+      imagePullPolicy: "Always"
+


### PR DESCRIPTION
This PR contains three polyaxon files to run horovod-enabled experiments for keras, tensorflow and pytorch in a single node setup using multiple GPUs.

This is an alternative to running experiments as MPI jobs in the platform when users want to run an experiment on a single machine but exploiting more than one GPU.

I tested manually on a custom in cluster setup with nodes with more than one GPU available. I created a docker image with openMPI and the frameworks installed, similar to the Dockerfile available in the corresponding folders.