### PR TITLE
Remove private TensorFlow API imports

### DIFF
--- a/core/polyaxon/tracking/contrib/keras.py
+++ b/core/polyaxon/tracking/contrib/keras.py
@@ -25,18 +25,14 @@ from polyaxon.utils.np_utils import sanitize_np_types
 
 try:
     from tensorflow import keras
-    from tensorflow.keras.callbacks import Callback
-    from tensorflow.python.keras.callbacks import ModelCheckpoint
 except ImportError:
     try:
         import keras
-
-        from keras.callbacks import Callback, ModelCheckpoint
     except ImportError:
         raise PolyaxonClientException("Keras is required to use PolyaxonCallback")
 
 
-class PolyaxonCallback(Callback):
+class PolyaxonCallback(keras.callbacks.Callback):
     def __init__(
         self,
         run=None,


### PR DESCRIPTION
This PR simplifies the TensorFlow imports and instead uses the public TensorFlow API in favour of the private `tensorflow.python` imports.