### PR TITLE
Do not rely on bare Python `except:`

### DIFF
--- a/core/polyaxon/agents/base.py
+++ b/core/polyaxon/agents/base.py
@@ -61,7 +61,7 @@ class BaseAgent:
     def get_healthz_config(cls):
         try:
             return ChecksConfig.read(cls.HEALTH_FILE, config_type=".json")
-        except:
+        except Exception:
             return
 
     @classmethod

--- a/core/polyaxon/cli/components/wait.py
+++ b/core/polyaxon/cli/components/wait.py
@@ -42,7 +42,7 @@ def wait(uuid: str, kind: str, max_retries: int):
     while retry < max_retries:
         try:
             k8s_operation = spawner.get(run_uuid=uuid, run_kind=kind)
-        except:  # noqa
+        except Exception:
             k8s_operation = None
         if k8s_operation:
             retry += 1

--- a/core/polyaxon/logger.py
+++ b/core/polyaxon/logger.py
@@ -22,11 +22,6 @@ from functools import wraps
 
 from polyaxon.env_vars.keys import POLYAXON_KEYS_DEBUG, POLYAXON_KEYS_LOG_LEVEL
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 
 logger = logging.getLogger("polyaxon.cli")
 
@@ -54,7 +49,7 @@ def configure_logger(verbose):
         if settings.CLIENT_CONFIG.log_level:
             try:
                 log_level = logging.getLevelName(settings.CLIENT_CONFIG.log_level)
-            except:  # noqa
+            except Exception:
                 pass
     logging.basicConfig(format="%(message)s", level=log_level, stream=sys.stdout)
 

--- a/core/polyaxon/parser/parser.py
+++ b/core/polyaxon/parser/parser.py
@@ -794,7 +794,7 @@ def get_image_init(
         if not isinstance(x, Mapping):
             try:
                 x = convert_to_dict(x, key)
-            except:
+            except Exception:
                 return x
 
         if "name" not in x:

--- a/core/polyaxon/polyboard/processors/events_processors.py
+++ b/core/polyaxon/polyboard/processors/events_processors.py
@@ -547,7 +547,7 @@ def figure_to_image(figure, close=True):
     if close:
         try:
             plt.close(figure.number)
-        except:
+        except Exception:
             plt.close(figure)
     return image_chw
 

--- a/core/polyaxon/tracking/contrib/fastai.py
+++ b/core/polyaxon/tracking/contrib/fastai.py
@@ -38,7 +38,7 @@ class PolyaxonCallback(Callback):
             self.plx_run.log_inputs(
                 n_epoch=str(self.learn.n_epoch), model_class=str(type(self.learn.model))
             )
-        except:
+        except Exception:
             print("Did not log all properties to Polyaxon.")
 
         try:
@@ -46,7 +46,7 @@ class PolyaxonCallback(Callback):
             with open(model_summary_path, "w") as g:
                 g.write(repr(self.learn.model))
             self.plx_run.log_file_ref(path=model_summary_path, name="model_summary")
-        except:
+        except Exception:
             print(
                 "Did not log model summary. "
                 "Check if your model is PyTorch model and that Polyaxon has correctly initialized "

--- a/core/polyaxon/tracking/contrib/keras.py
+++ b/core/polyaxon/tracking/contrib/keras.py
@@ -93,12 +93,12 @@ class PolyaxonCallback(Callback):
 
         try:
             params["num_layers"] = len(self.model.layers)
-        except:  # noqa
+        except Exception:
             pass
 
         try:
             params["optimizer_name"] = type(self.model.optimizer).__name__
-        except:  # noqa
+        except Exception:
             pass
 
         try:
@@ -108,7 +108,7 @@ class PolyaxonCallback(Callback):
                     if type(self.model.optimizer.lr) is float
                     else keras.backend.eval(self.model.optimizer.lr)
                 )
-        except:  # noqa
+        except Exception:
             pass
 
         try:
@@ -118,7 +118,7 @@ class PolyaxonCallback(Callback):
                     if type(self.model.optimizer.epsilon) is float
                     else keras.backend.eval(self.model.optimizer.epsilon)
                 )
-        except:  # noqa
+        except Exception:
             pass
 
         if params:
@@ -132,7 +132,7 @@ class PolyaxonCallback(Callback):
             with open(rel_path, "w") as f:
                 f.write(summary)
             self.run.log_file_ref(path=rel_path)
-        except:  # noqa
+        except Exception:
             pass
 
     @client_handler(check_no_op=True)

--- a/core/polyaxon/utils/cache.py
+++ b/core/polyaxon/utils/cache.py
@@ -27,7 +27,7 @@ CACHE_ERROR = (
 def get_local_project():
     try:
         return ProjectConfigManager.get_config()
-    except:
+    except Exception:
         Printer.print_error(CACHE_ERROR, sys_exit=True)
 
 

--- a/core/polyaxon/utils/encoding.py
+++ b/core/polyaxon/utils/encoding.py
@@ -32,5 +32,5 @@ def urlsafe_b64decode(b64string):
     payload = base64.urlsafe_b64decode(padded)
     try:
         return payload.decode("utf-8")
-    except:
+    except Exception:
         return payload

--- a/core/polyaxon/utils/formatting.py
+++ b/core/polyaxon/utils/formatting.py
@@ -49,12 +49,12 @@ def get_meta_response(response):
     if response.next:
         try:
             results["next"] = get_pagination(response.next)
-        except:  # noqa
+        except Exception:
             results["next"] = response.next
     if response.previous:
         try:
             results["previous"] = get_pagination(response.previous)
-        except:  # noqa
+        except Exception:
             results["previous"] = response.previous
     if response.count:
         results["count"] = response.count

--- a/platform/polycommon/polycommon/apis/index/health.py
+++ b/platform/polycommon/polycommon/apis/index/health.py
@@ -35,7 +35,7 @@ class HealthView(APIView):
     def get_config(self):
         try:
             return CliConfig.read(self.HEALTH_FILE, config_type=".json")
-        except:  # noqa
+        except Exception:
             return
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
> A bare `except:` clause will catch `SystemExit` and `KeyboardInterrupt` exceptions, making it harder to interrupt a program with Control-C. (from https://www.flake8rules.com/rules/E722.html:)

I don't think this is desired in these cases so this PR replaces bare `except:` clauses with `except Exception:` which still catches all exceptions that signal program errors.