### PR TITLE
GCS: Fix deletion of directories containing empty files

### DIFF
--- a/core/polyaxon/connections/gcp/gcs.py
+++ b/core/polyaxon/connections/gcp/gcs.py
@@ -144,8 +144,8 @@ class GCSService(GCPService, StoreMixin):
             for blob in _blobs:
                 name = blob.name[len(key) :]
                 size = blob.size
-                if all([name, size]):
-                    list_blobs.append((name, blob.size))
+                if name and size is not None:
+                    list_blobs.append((name, size))
             return list_blobs
 
         def get_prefixes(_prefixes):


### PR DESCRIPTION
This PR fixes a bug when trying to delete directories containing empty files. The code on master failed since `size=0` is actually a valid size for a file or blob on GCS which would lead to GCS trying to delete a non-empty directory which fails.

This happens frequently when using the upload command with a Python codebase since there usually exists many empty `__init__.py` files.

This should fix #1273.
It would probably be good to add a test verifying this behaviour for the other storages backends as well. To be honest I am a bit surprised that this hasn't been caught before making me think I am missing something obvious, but I verified this manually and it seem to actually fix my issue.