### PR TITLE
GCS: Speedup deletion

### DIFF
--- a/core/polyaxon/connections/gcp/gcs.py
+++ b/core/polyaxon/connections/gcp/gcs.py
@@ -339,29 +339,16 @@ class GCSService(GCPService, StoreMixin):
         if not bucket_name:
             bucket_name, key = self.parse_gcs_url(key)
 
-        results = self.list(bucket_name=bucket_name, key=key, delimiter="/")
-        if not any([results["prefixes"], results["blobs"]]):
-            self.delete_file(key=key, bucket_name=bucket_name)
-
-        # Delete directories
-        for prefix in sorted(results["prefixes"]):
-            prefix = os.path.join(key, prefix)
-            # Download files under
-            self.delete(key=prefix, bucket_name=bucket_name)
-
+        blobs = self.connection.list_blobs(bucket_name, prefix=key)
         pool, future_results = self.init_pool(workers)
 
         # Delete files
-        for file_key in results["blobs"]:
-            file_key = file_key[0]
-            file_key = os.path.join(key, file_key)
+        for blob in blobs:
             future_results = self.submit_pool(
                 workers=workers,
                 pool=pool,
                 future_results=future_results,
-                fn=self.delete_file,
-                key=file_key,
-                bucket_name=bucket_name,
+                fn=blob.delete,
             )
 
         if workers:

--- a/core/polyaxon/connections/gcp/gcs.py
+++ b/core/polyaxon/connections/gcp/gcs.py
@@ -348,7 +348,8 @@ class GCSService(GCPService, StoreMixin):
                 workers=workers,
                 pool=pool,
                 future_results=future_results,
-                fn=blob.delete,
+                fn=_delete_blob,
+                blob=blob,
             )
 
         if workers:
@@ -363,3 +364,10 @@ class GCSService(GCPService, StoreMixin):
             return bucket.delete_blob(key)
         except (NotFound, GoogleAPIError) as e:
             raise PolyaxonStoresException("Connection error: %s" % e) from e
+
+
+def _delete_blob(blob):
+    try:
+        return blob.delete()
+    except (NotFound, GoogleAPIError) as e:
+        raise PolyaxonStoresException("Connection error: %s" % e) from e

--- a/core/polyaxon/connections/gcp/gcs.py
+++ b/core/polyaxon/connections/gcp/gcs.py
@@ -137,7 +137,9 @@ class GCSService(GCPService, StoreMixin):
             prefix += "/"
 
         def get_iterator():
-            return bucket.list_blobs(prefix=prefix, delimiter=delimiter)
+            return self.connection.list_blobs(
+                bucket, prefix=prefix, delimiter=delimiter
+            )
 
         def get_blobs(_blobs):
             list_blobs = []

--- a/core/polyaxon/connections/gcp/gcs.py
+++ b/core/polyaxon/connections/gcp/gcs.py
@@ -124,8 +124,6 @@ class GCSService(GCPService, StoreMixin):
         if not bucket_name:
             bucket_name, key = self.parse_gcs_url(key)
 
-        bucket = self.get_bucket(bucket_name)
-
         if key and not key.endswith("/"):
             key += "/"
 
@@ -138,7 +136,7 @@ class GCSService(GCPService, StoreMixin):
 
         def get_iterator():
             return self.connection.list_blobs(
-                bucket, prefix=prefix, delimiter=delimiter
+                bucket_name, prefix=prefix, delimiter=delimiter
             )
 
         def get_blobs(_blobs):

--- a/core/tests/test_connections/test_gcp/test_gcs_store.py
+++ b/core/tests/test_connections/test_gcp/test_gcs_store.py
@@ -148,9 +148,6 @@ class TestGCSStore(BaseTestCase):
     def test_list_empty(self, client, _):
         gcs_url = "gs://bucket/path/to/blob"
         store = GCSService()
-        client.return_value.get_bucket.return_value.list_blobs.return_value = (
-            mock.MagicMock()
-        )
         assert store.list(gcs_url) == {"blobs": [], "prefixes": []}
 
     @mock.patch(GCS_MODULE.format("get_gc_credentials"))
@@ -171,9 +168,7 @@ class TestGCSStore(BaseTestCase):
         mock_results.configure_mock(pages=[dir_mock])
         mock_results.__iter__.return_value = [obj_mock]
 
-        client.return_value.get_bucket.return_value.list_blobs.return_value = (
-            mock_results
-        )
+        client.return_value.list_blobs.return_value = mock_results
 
         store = GCSService()
         results = store.list(gcs_url)
@@ -204,9 +199,7 @@ class TestGCSStore(BaseTestCase):
         mock_results.configure_mock(pages=[subdir_mock])
         mock_results.__iter__.return_value = [obj_mock]
 
-        client.return_value.get_bucket.return_value.list_blobs.return_value = (
-            mock_results
-        )
+        client.return_value.list_blobs.return_value = mock_results
 
         store = GCSService()
         results = store.list(gcs_url, path=dirname)
@@ -456,14 +449,12 @@ class TestGCSStore(BaseTestCase):
         mock_results2.configure_mock(pages=[])
         mock_results2.__iter__.return_value = [obj_mock3]
 
-        def list_side_effect(prefix, delimiter="/"):
+        def list_side_effect(bucket_name, prefix, delimiter="/"):
             if prefix == blob_path:
                 return mock_results1
             return mock_results2
 
-        client.return_value.get_bucket.return_value.list_blobs.side_effect = (
-            list_side_effect
-        )
+        client.return_value.list_blobs.side_effect = list_side_effect
 
         dirname3 = tempfile.mkdtemp()
 
@@ -532,14 +523,12 @@ class TestGCSStore(BaseTestCase):
         mock_results2.configure_mock(pages=[])
         mock_results2.__iter__.return_value = [obj_mock3]
 
-        def list_side_effect(prefix, delimiter="/"):
+        def list_side_effect(bucket_name, prefix, delimiter="/"):
             if prefix == blob_path + "foo/":
                 return mock_results1
             return mock_results2
 
-        client.return_value.get_bucket.return_value.list_blobs.side_effect = (
-            list_side_effect
-        )
+        client.return_value.list_blobs.side_effect = list_side_effect
 
         dirname3 = tempfile.mkdtemp()
 


### PR DESCRIPTION
This PR simplifies and improves the performance of deletion of GCS directories also working around issues like #1273.

In my testing deleting a 526.76 MiB directory of 277 objects over wifi with 5 workers sped up **8x** (from 39.8 s to 4.95 s wall time).

I only tested this manually, so I am not sure if I am missing some edge cases, but I checked that all objects have been removed.