### PR TITLE
Upgrade Polytune requirements

### DIFF
--- a/core/requirements/requirements-dev.txt
+++ b/core/requirements/requirements-dev.txt
@@ -4,8 +4,8 @@ docker
 GitPython<3.2.0
 
 numpy>=1.15.2
-scikit-learn==0.23.2
-hyperopt==0.2.4
+scikit-learn==0.24.1
+hyperopt==0.2.5
 nbconvert>=5.4.0,<6.0.0
 
 azure-storage-blob==12.4.0

--- a/core/setup.py
+++ b/core/setup.py
@@ -92,7 +92,7 @@ setup(
         "docker": ["docker"],
         "git": ["gitpython"],
         "numpy": ["numpy"],
-        "polytune": ["scikit-learn==0.23.2", "hyperopt==0.2.4"],
+        "polytune": ["scikit-learn==0.24.1", "hyperopt==0.2.5"],
         "polyboard": [
             "Pillow",
             "matplotlib<3.3.3",

--- a/examples/tracking/sklearn/newsgroup/requirements.txt
+++ b/examples/tracking/sklearn/newsgroup/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==0.22.2
+scikit-learn==0.24.1
 polyaxon

--- a/examples/tracking/sklearn/random_forest/requirements.txt
+++ b/examples/tracking/sklearn/random_forest/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==0.22.2
+scikit-learn==0.24.1
 polyaxon

--- a/examples/tracking/sklearn/sgd_classifier/requirements.txt
+++ b/examples/tracking/sklearn/sgd_classifier/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==0.22.2
+scikit-learn==0.24.1
 polyaxon

--- a/examples/tracking/xgboost/iris/requirements.txt
+++ b/examples/tracking/xgboost/iris/requirements.txt
@@ -1,3 +1,3 @@
 xgboost
-scikit-learn==0.22.2
+scikit-learn==0.24.1
 polyaxon


### PR DESCRIPTION
This PR upgrades the Polytune dependencies. In particular scikit-learn now ships with prebuilts wheels for Python 3.9 which should help install times (also on CI).