### PR TITLE
GCS: Sort directories when listing objects

### DIFF
--- a/core/polyaxon/connections/gcp/gcs.py
+++ b/core/polyaxon/connections/gcp/gcs.py
@@ -140,7 +140,7 @@ class GCSService(GCPService, StoreMixin):
             return list_blobs
 
         def get_prefixes(prefixes):
-            return [folder_path[len(key) : -1] for folder_path in prefixes]
+            return sorted([folder_path[len(key) : -1] for folder_path in prefixes])
 
         iterator = self.connection.list_blobs(
             bucket_name, prefix=prefix, delimiter=delimiter


### PR DESCRIPTION
`iterator.prefixes` is a `set()` which might might not be ordered. This PR makes sure to sort the listed directories to ensure correct ordering.