### PR TITLE
Docs: clarify S3-compatible endpoint usage for the S3 data and artifacts stores

### DIFF
--- a/site/integrations/artifacts/artifacts-on-s3.mdx
+++ b/site/integrations/artifacts/artifacts-on-s3.mdx
@@ -22,6 +22,11 @@ And optionally these keys:
  * `AWS_SECURITY_TOKEN`
  * `AWS_REGION`
 
+Because the artifacts store relies on the standard S3 environment variables, it works with Amazon S3 or any S3-compatible object storage service (for example Backblaze B2, Cloudflare R2, or MinIO). Leave `AWS_ENDPOINT_URL` unset to use the default Amazon S3 endpoint, or set it to your provider's endpoint:
+
+```bash
+AWS_ENDPOINT_URL: "https://your-s3-endpoint.example.com"
+```
 
 ## Create a secret or a config map for storing these keys
 

--- a/site/integrations/data-stores/data-on-s3.mdx
+++ b/site/integrations/data-stores/data-on-s3.mdx
@@ -22,6 +22,12 @@ And optionally these keys:
  * `AWS_SECURITY_TOKEN`
  * `AWS_REGION`
 
+Because the connection relies on the standard S3 environment variables, it works with Amazon S3 or any S3-compatible object storage service (for example Backblaze B2, Cloudflare R2, or MinIO). Leave `AWS_ENDPOINT_URL` unset to use the default Amazon S3 endpoint, or set it to your provider's endpoint:
+
+```bash
+AWS_ENDPOINT_URL: "https://s3.<region>.<provider-domain>"
+```
+
 ## Create a secret or a config map for storing these keys
 
 We recommend using a secret to store your access information json object:


### PR DESCRIPTION
Both the S3 data store and the S3 artifacts store pages already list `AWS_ENDPOINT_URL` among the optional keys, but neither page says what it is for. This adds a short note to each page explaining that the connection relies on the standard S3 environment variables, so it works with Amazon S3 or any S3-compatible object storage service, and that `AWS_ENDPOINT_URL` can be left unset for the default Amazon S3 endpoint or set to another provider's endpoint. The note names Backblaze B2, Cloudflare R2, and MinIO as examples, and the snippets use placeholder endpoints.

Documentation only, one commit per page. No code or behavior changes.
